### PR TITLE
Update Default.sublime-keymap

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -4,5 +4,5 @@
 	{ "keys": ["ctrl+r"], "command": "show_panel", "args": {"panel": "output.exec"} },
 	{ "keys": ["f5"], "command": "build" },
 	{ "keys": ["ctrl+tab"], "command": "next_view" },
-	{ "keys": ["ctrl+shift+tab"], "command": "prev_view" },
+	{ "keys": ["ctrl+shift+tab"], "command": "prev_view" }
 ]


### PR DESCRIPTION
Fixing trailing comma error while parsing Default.sublime-keymap.
