### PR TITLE
Use explicit count modifiers

### DIFF
--- a/Pawn.tmLanguage
+++ b/Pawn.tmLanguage
@@ -1194,7 +1194,7 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>match</key> <string>\\(\\|[abefnprtv'"?]|[0-3]\d{,2}|[4-7]\d?|x[a-fA-F0-9]{,2}|u[a-fA-F0-9]{,4}|U[a-fA-F0-9]{,8})</string>
+					<key>match</key> <string>\\(\\|[abefnprtv'"?]|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8})</string>
 					<key>name</key> <string>constant.character.escape.c</string>
 				</dict>
 				<dict>


### PR DESCRIPTION
The construction `{,n}` in regular expressions is only supported by Oniguruma (which is used by Sublime Text). This Sublime Text package is used to highlight Pawn code on github.com. However, github.com is using a [PCRE-based engine](https://github.com/vmg/pcre) for regexes.

This pull request fixes that by using explicit count modifiers.